### PR TITLE
Include correct dependencies for testsuite-shading on windows. (#8491)

### DIFF
--- a/testsuite-shading/pom.xml
+++ b/testsuite-shading/pom.xml
@@ -66,6 +66,35 @@
   </dependencies>
   <profiles>
     <profile>
+      <id>windows</id>
+      <activation>
+        <os>
+          <family>windows</family>
+        </os>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>netty-common</artifactId>
+          <version>${project.version}</version>
+          <scope>compile</scope>
+        </dependency>
+        <dependency>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>netty-handler</artifactId>
+          <version>${project.version}</version>
+          <scope>compile</scope>
+        </dependency>
+        <dependency>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>${tcnative.artifactId}</artifactId>
+          <version>${tcnative.version}</version>
+          <classifier>${tcnative.classifier}</classifier>
+          <scope>compile</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
       <id>mac</id>
       <activation>
         <os>
@@ -76,6 +105,12 @@
         <nativeTransportLib>netty_transport_native_kqueue_${os.detected.arch}.jnilib</nativeTransportLib>
       </properties>
       <dependencies>
+        <dependency>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>netty-common</artifactId>
+          <version>${project.version}</version>
+          <scope>compile</scope>
+        </dependency>
         <dependency>
           <groupId>${project.groupId}</groupId>
           <artifactId>netty-transport-native-kqueue</artifactId>
@@ -214,6 +249,12 @@
         <nativeTransportLib>netty_transport_native_epoll_${os.detected.arch}.so</nativeTransportLib>
       </properties>
       <dependencies>
+        <dependency>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>netty-common</artifactId>
+          <version>${project.version}</version>
+          <scope>compile</scope>
+        </dependency>
         <dependency>
           <groupId>${project.groupId}</groupId>
           <artifactId>netty-transport-native-epoll</artifactId>

--- a/testsuite-shading/src/test/java/io/netty/testsuite/shading/ShadingIT.java
+++ b/testsuite-shading/src/test/java/io/netty/testsuite/shading/ShadingIT.java
@@ -17,6 +17,7 @@ package io.netty.testsuite.shading;
 
 import io.netty.util.internal.PlatformDependent;
 import org.junit.Test;
+import org.junit.Assume;
 
 import java.lang.reflect.Method;
 
@@ -27,6 +28,9 @@ public class ShadingIT {
 
     @Test
     public void testShadingNativeTransport() throws Exception {
+        // Skip on windows.
+        Assume.assumeFalse(PlatformDependent.isWindows());
+
         String className = PlatformDependent.isOsx() ?
                 "io.netty.channel.kqueue.KQueue" : "io.netty.channel.epoll.Epoll";
         testShading0(SHADING_PREFIX, className);
@@ -35,6 +39,9 @@ public class ShadingIT {
 
     @Test
     public void testShadingTcnative() throws Exception {
+        // Skip on windows.
+        Assume.assumeFalse(PlatformDependent.isWindows());
+
         String className = "io.netty.handler.ssl.OpenSsl";
         testShading0(SHADING_PREFIX, className);
         testShading0(SHADING_PREFIX2, className);


### PR DESCRIPTION
Motivation:

We missed to include a profile for windows which means that we did not have the correct dependencies setup.

Modifications:

- Add missing profile
- Add assumeFalse(...) to ensure we do only test the native transpot shading on non windows platforms.
- Explicit specify dependency on netty-common

Result:

Fixes https://github.com/netty/netty/issues/8489.

Motivation:

Explain here the context, and why you're making that change.
What is the problem you're trying to solve.

Modification:

Describe the modifications you've done.

Result:

Fixes #<GitHub issue number>. 

If there is no issue then describe the changes introduced by this PR.
